### PR TITLE
move the definition of RawCommand here

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,15 +1,14 @@
 rock_library(controldev
     SOURCES Joystick.cpp
-	    LogitechG27.cpp  
-	    SliderBox.cpp 
+	    LogitechG27.cpp
+	    SliderBox.cpp
             ConnexionHID.cpp
-    HEADERS Joystick.hpp  
-	    LogitechG27.hpp  
+    HEADERS Joystick.hpp
+	    LogitechG27.hpp
 	    SliderBox.hpp
             ConnexionHID.hpp
+            RawCommand.hpp
     DEPS_PKGCONFIG libsysfs libusb)
-
-
 
 rock_executable(JoystickTest JoystickTest.cpp
     DEPS controldev)

--- a/src/RawCommand.hpp
+++ b/src/RawCommand.hpp
@@ -1,0 +1,40 @@
+#ifndef CONTROLDEV_RAW_COMMAND_HPP
+#define CONTROLDEV_RAW_COMMAND_HPP
+
+#include <base/Time.hpp>
+#include <string>
+#include <vector>
+
+namespace controldev {
+    /** A data structure for raw data values of input devices
+     */
+    struct RawCommand
+    {
+        /*
+         * Device Type identifier like
+         */
+        std::string deviceIdentifier;
+
+        /*
+         * The timestamp
+         */
+        base::Time time;
+
+        /**
+         * Axis values, scaled betwen 0 and 1.
+         * */
+        std::vector<double> axisValue;
+
+        /*
+         * Button state (either 0 or 1)
+         *
+         * Three State switches are handles as two
+         *
+         * Bool vectors are not supported by orogen. This is why it is using bytes
+         */
+        std::vector<uint8_t> buttonValue;
+    };
+}
+
+#endif
+


### PR DESCRIPTION
Depends on:
- [ ] https://github.com/rock-drivers/drivers-orogen-controldev/pull/10

It was defined in the orogen component, which made it impossible to
use in other libraries (e.g. libraries that would convert raw commands
to other types of commands). Move it here to make it available at
the library level.